### PR TITLE
Make romsize extern & add header guard

### DIFF
--- a/include/c_defs.h
+++ b/include/c_defs.h
@@ -1,3 +1,6 @@
+#ifndef C_DEFS_H
+#define C_DEFS_H
+
 //FIFO_USER_06	for ipc_region
 //FIFO_USER_07	for audio data
 //FIFO_USER_08  for APU control
@@ -91,7 +94,7 @@ extern u32 debuginfo[];
 int debugdump(void);
 
 //romloader.c
-int romsize;
+extern int romsize;
 int bootext();
 extern int active_interface;
 extern char romfilename[256];
@@ -319,4 +322,6 @@ int do_decompression(const char *inname, const char *outname);
 #define NSFFILE 0x100000 //on or off state of all_pix_show
 #else
 extern int ipc_region;
+#endif
+
 #endif


### PR DESCRIPTION
This simply makes `int romsize` in `c_defs.h` be `extern` which fixes the linking errors and adds a header guard for that file since it's just better to have one. I did not test that the output works, but it does compile and link to produce an nds file.